### PR TITLE
Set content of resources to sensitive

### DIFF
--- a/main.go
+++ b/main.go
@@ -48,8 +48,9 @@ func resourceManifest() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"content": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
+				Type:      schema.TypeString,
+				Required:  true,
+				Sensitive: true,
 			},
 		},
 	}


### PR DESCRIPTION
Not sure if you'll want this or not. I am using this for secrets and wanted to avoid having them (albeit base64encoded) show up in my terminal every time I changed them. Another option here could be to create a second resource type called something like `k8s_manifest_sensitive` that marks the input as sensitive. Up to you! I'll be happy to make that change if you want it.

Thanks for this provider, it has been a lifesaver.