### PR TITLE
Add kubeconfig_content configuration parameter to the provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,27 @@ providers {
 }
 ```
 
-The provider takes optional configuration to specify a `kubeconfig` file:
+The provider takes the following optional configuration parameters:
+
+* If you have a kubeconfig available on the file system you can configure the provider as:
 
 ```hcl
 provider "k8s" {
   kubeconfig = "/path/to/kubeconfig"
 }
 ```
+
+* If you content of the kubeconfig is available in a variable, you can configure the provider as:
+
+```hcl
+provider "k8s" {
+  kubeconfig_content = "${var.kubeconfig}"
+}
+```
+
+**WARNING:** Configuration from the variable will be recorded into a temporary file and the file will be removed as
+soon as call is completed. This may impact performance if the code runs on a shared system because
+and the global tempdir is used.
 
 The k8s Terraform provider introduces a single Terraform resource, a `k8s_manifest`. The resource contains a `content` field, which contains a raw manifest.
 


### PR DESCRIPTION
Problem this change solves: 
If kubeconfig is stored somewhere (configuration servers, AWS SSM, etc.) but not on the file system then `terraform plan` will fail because the provider needs the config to check the state but the file can be created only when `plan` is done.

I hit this problem on AWS: I manage environments from a container in a build pipeline and kubeconfig  is generated by another module (https://github.com/terraform-aws-modules/terraform-aws-eks). This fix allows to pass variable with kubeconfig directly to the provider and complete both `plan` and `apply` phases successfully.