### PR TITLE
Unescape the resource and namespace to allow names with : in them

### DIFF
--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"net/url"
 	"os"
 	"os/exec"
 	"strings"
@@ -189,6 +190,15 @@ func resourceFromSelflink(s string) (resource, namespace string, ok bool) {
 			break
 		}
 	}
+
+	var err error
+	if resource, err = url.PathUnescape(resource); err != nil {
+		return "", "", false
+	}
+	if namespace, err = url.PathUnescape(namespace); err != nil {
+		return "", "", false
+	}
+
 	return resource, namespace, true
 }
 


### PR DESCRIPTION
This fixes #18 by un-escaping the portions of the self link URL which represent the namespace and resource name.